### PR TITLE
Updated README.bn.adoc: For arch linux, the fcitx5 package was written 'fcit5'

### DIFF
--- a/README.bn.adoc
+++ b/README.bn.adoc
@@ -90,7 +90,7 @@ sudo dnf install @buildsys-build rust cargo cmake qt5-qtdeclarative-devel ibus-d
 === আর্চলিনাক্স ভিত্তিক
 আর্চলিনাক্স ভিত্তিক সিস্টেমে ডিপেন্ডেসিগুলো ইনস্টলের কমান্ড:
 ```bash
-sudo pacman -S base-devel rust cmake qt5-base libibus zstd fcit5 fcitx5-configtool git
+sudo pacman -S base-devel rust cmake qt5-base libibus zstd fcitx5 fcitx5-configtool git
 ```
 
 === ওপেনসুস ভিত্তিক


### PR DESCRIPTION
It was written "fcit5" in the package installation for Arch Linux. Fixed it to "fcitx5"